### PR TITLE
Fix Windows Link Script

### DIFF
--- a/scripts/link.bat
+++ b/scripts/link.bat
@@ -4,8 +4,8 @@ set components=cart cat configuration sensor staff uart_bridge
 set programs=main\column_controller main\network_hub main\conductor utility\column_checker
 
 for %%G in (%programs%) do (
-    rmdir firmware\main\%%G\src\components /s /q
-    mkdir firmware\main\%%G\src\components
+    rmdir firmware\%%G\src\components /s /q
+    mkdir firmware\%%G\src\components
     for %%H in (%components%) do (
         mklink /J firmware\%%G\src\components\%%H firmware\components\%%H
     )


### PR DESCRIPTION
This fixes the windows link script which failed due to an erroneous 'main' dir in some paths